### PR TITLE
build: add devcontainers & fix ci

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// https://aka.ms/devcontainer.json
+{
+	"name": "Existing Docker Compose (Extend)",
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+	"service": "laravel.test",
+	"workspaceFolder": "/var/www/html",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"laravel.vscode-laravel",
+				"mikestead.dotenv",
+				"amiralizadeh9480.laravel-extra-intellisense",
+				"ryannaddy.laravel-artisan",
+				"onecentlin.laravel5-snippets",
+				"onecentlin.laravel-blade"
+			],
+			"settings": {}
+		}
+	},
+	"remoteUser": "sail",
+	"postCreateCommand": "chown -R 1000:1000 /var/www/html 2>/dev/null || true"
+	// "forwardPorts": [],
+	// "runServices": [],
+	// "shutdownAction": "none",
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   php-version: '8.2'
-  node-version: 20
+  node-version: 22
 
 concurrency:
   group: Build ${{ github.ref }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,7 +5,7 @@ on:
     types: [labeled, opened, synchronize, reopened]
 
 env:
-  node-version: 20
+  node-version: 22
 
 concurrency:
   group: Cypress tests ${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   php-version: '8.2'
-  node-version: 20
+  node-version: 22
 
 concurrency:
   group: Deploy ${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,7 +156,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Download assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v5
         with:
           name: assets
           path: public
@@ -211,13 +211,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v5
         with:
           name: assets
           path: public
 
       - name: Download source maps
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v5
         with:
           name: sourcemaps
           path: public

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,7 @@ jobs:
         run: yarn run production
 
       - name: Store assets
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: assets
           path: |
@@ -127,7 +127,7 @@ jobs:
             !public/**/*.map
 
       - name: Store source maps
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sourcemaps
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Store changelog file
         if: steps.semantic.outputs.new_release_published == 'true'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: changelog
           path: CHANGELOG.md
@@ -77,7 +77,7 @@ jobs:
         with:
           ref: v${{ needs.semantic.outputs.new_release_version }}
       - name: Download changelog file
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v5
         with:
           name: changelog
 
@@ -141,13 +141,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Store package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package
           path: ${{ steps.package.outputs.package }}
 
       - name: Store assets
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: assets
           path: ${{ steps.package.outputs.assets }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: results
+          name: results-${{ matrix.testsuite }}
           path: results
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -301,7 +301,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Download results
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v5
         with:
           path: results
           name: results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -246,7 +246,7 @@ jobs:
       - name: Start Chrome Driver
         run: |
           chmod -R 0755 vendor/laravel/dusk/bin/
-          ./vendor/laravel/dusk/bin/chromedriver-linux &
+          ./vendor/laravel/dusk/bin/chromedriver-linux64/chromedriver &
 
       - name: Run http server
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,9 +240,18 @@ jobs:
       - name: Test coverage page
         run: REQUEST_URI=/ php scripts/tests/server-cc.php
 
+      - uses: browser-actions/setup-chrome@v2
+        id: setup-chrome
+        with:
+          chrome-version: 126
+          install-chromedriver: true
+
     # Test
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver --detect
+        run: |
+          # https://stackoverflow.com/questions/78827506/invalid-path-to-chromedriver-when-running-laravel-dusk
+          # revert to `--detect` once updating to Laravel 9+
+          php artisan dusk:chrome-driver 126
       - name: Start Chrome Driver
         run: |
           chmod -R 0755 vendor/laravel/dusk/bin/
@@ -257,6 +266,7 @@ jobs:
         run: php artisan dusk --log-junit results/junit/results0.xml
         env:
           APP_URL: http://localhost:8000
+          CHROME_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
 
       - name: Fix coverage
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   default-php-version: '8.2'
-  node-version: 20
+  node-version: 22
 
 concurrency:
   group: Unit tests ${{ github.ref }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Store results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: results
           path: results
@@ -269,7 +269,7 @@ jobs:
 
       - name: Store results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: results
           path: results

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
         "khanamiryan/qrcode-detector-decoder": "^2.0",
         "laravel/dusk": "^7.11",
         "laravel/legacy-factories": "^1.0",
+        "laravel/sail": "*",
         "laravel/tinker": "^2.6",
         "matthiasnoback/live-code-coverage": "^1",
         "mockery/mockery": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf135499df1575ba5a5747a5fcf4289c",
+    "content-hash": "44eb40217df946fd0ced754d07492fcf",
     "packages": [
         {
             "name": "asbiin/laravel-adorable",
@@ -14654,6 +14654,69 @@
             "time": "2024-01-15T13:55:14+00:00"
         },
         {
+            "name": "laravel/sail",
+            "version": "v1.44.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sail.git",
+                "reference": "a09097bd2a8a38e23ac472fa6a6cf5b0d1c1d3fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/a09097bd2a8a38e23ac472fa6a6cf5b0d1c1d3fe",
+                "reference": "a09097bd2a8a38e23ac472fa6a6cf5b0d1c1d3fe",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^9.52.16|^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^9.52.16|^10.0|^11.0|^12.0",
+                "illuminate/support": "^9.52.16|^10.0|^11.0|^12.0",
+                "php": "^8.0",
+                "symfony/console": "^6.0|^7.0",
+                "symfony/yaml": "^6.0|^7.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+                "phpstan/phpstan": "^1.10"
+            },
+            "bin": [
+                "bin/sail"
+            ],
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sail\\SailServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sail\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Docker files for running a basic Laravel application.",
+            "keywords": [
+                "docker",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sail/issues",
+                "source": "https://github.com/laravel/sail"
+            },
+            "time": "2025-07-04T16:17:06+00:00"
+        },
+        {
             "name": "laravel/tinker",
             "version": "v2.9.0",
             "source": {
@@ -19666,8 +19729,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "werk365/etagconditionals": 20,
-        "roave/security-advisories": 20
+        "roave/security-advisories": 20,
+        "werk365/etagconditionals": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,
@@ -19679,6 +19742,6 @@
         "ext-intl": "*",
         "ext-redis": "*"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+    laravel.test:
+        build:
+            context: ./vendor/laravel/sail/runtimes/8.4
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+        image: sail-8.4/app
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        ports:
+            - '${APP_PORT:-80}:80'
+            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+            IGNITION_LOCAL_SITES_PATH: '${PWD}'
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            - mysql
+    mysql:
+        image: 'mysql/mysql-server:8.0'
+        ports:
+            - '${FORWARD_DB_PORT:-3306}:3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ROOT_HOST: '%'
+            MYSQL_DATABASE: '${DB_DATABASE}'
+            MYSQL_USER: '${DB_USERNAME}'
+            MYSQL_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ALLOW_EMPTY_PASSWORD: 1
+            MYSQL_EXTRA_OPTIONS: '${MYSQL_EXTRA_OPTIONS}'
+        volumes:
+            - 'sail-mysql:/var/lib/mysql'
+            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+        networks:
+            - sail
+        healthcheck:
+            test:
+                - CMD
+                - mysqladmin
+                - ping
+                - '-p${DB_PASSWORD}'
+            retries: 3
+            timeout: 5s
+networks:
+    sail:
+        driver: bridge
+volumes:
+    sail-mysql:
+        driver: local

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "composer update": "COMPOSER_MEMORY_LIMIT=-1 composer update"
   },
   "engines": {
-    "node": "20.x",
+    "node": "22.x",
     "yarn": "1.22.x"
   },
   "devDependencies": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -56,7 +56,6 @@
     <env name="APP_ENV" value="testing"/>
     <env name="APP_KEY" value="base64:NTrXToqFZJlv48dgPc+kNpc3SBt333TfDnF1mDShsBg="/>
     <env name="BCRYPT_ROUNDS" value="4"/>
-    <env name="DB_CONNECTION" value="testing"/>
     <env name="CACHE_DRIVER" value="array"/>
     <env name="CHECK_VERSION" value="false"/>
     <env name="MAIL_MAILER" value="array"/>

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -51,8 +51,15 @@ abstract class DuskTestCase extends BaseTestCase
             return $items->merge([
                 '--disable-gpu',
                 '--headless',
+                // WORKAROUND: https://issues.chromium.org/issues/42323434#comment62
+                // Review after updating Chrome Driver
+                '--no-sandbox',
             ]);
         })->all());
+        $binary = env('CHROME_PATH');
+        if ($binary != null) {
+            $options->setBinary($binary);
+        }
 
         return RemoteWebDriver::create(
             $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:9515',


### PR DESCRIPTION
This should make development across devices a bit more seamless

- use Laravel Sail
- update supported node version to 22
- use actions/download-artifact@v5
- use actions/upload-artifact@v4
- lock in Chrome 126 because there is a bug with Laravel Dusk when using versions after that. Updating Dusk is not an option unless the whole Laravel framework is updated to 10+