### PR TITLE
fix: webauthn passkey creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
         "phpunit/phpcov": "^8.0",
         "phpunit/phpunit": "^9.0",
         "psalm/plugin-laravel": "^2.0",
+        "ryoluo/sail-ssl": "^1.4",
         "thecodingmachine/phpstan-safe-rule": "^1.0",
         "vimeo/psalm": "^5.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "429520890aa27233009d30cdd0798709",
+    "content-hash": "20a4f06d98cc59555f357bd2c5e4a184",
     "packages": [
         {
             "name": "asbiin/laravel-adorable",
@@ -16544,6 +16544,68 @@
                 "source": "https://github.com/bobthecow/psysh/tree/v0.12.10"
             },
             "time": "2025-08-04T12:39:37+00:00"
+        },
+        {
+            "name": "ryoluo/sail-ssl",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ryoluo/sail-ssl.git",
+                "reference": "0db9b67df79e245d9c22aa3aced3b2564a3213b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ryoluo/sail-ssl/zipball/0db9b67df79e245d9c22aa3aced3b2564a3213b8",
+                "reference": "0db9b67df79e245d9c22aa3aced3b2564a3213b8",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": ">=8.0",
+                "illuminate/contracts": ">=8.0",
+                "illuminate/support": ">=8.0",
+                "php": "^7.3|^8.0"
+            },
+            "require-dev": {
+                "laravel/sail": "^1.14",
+                "orchestra/testbench": ">=6.0",
+                "phpunit/phpunit": ">=9.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Ryoluo\\SailSsl\\SailSslServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ryoluo\\SailSsl\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ryo Kobayashi",
+                    "email": "ryoluo@lotus-base.com"
+                }
+            ],
+            "description": "Laravel Sail plugin to enable SSL (HTTPS) connection with Nginx.",
+            "keywords": [
+                "docker",
+                "laravel",
+                "nginx",
+                "sail",
+                "ssl"
+            ],
+            "support": {
+                "issues": "https://github.com/ryoluo/sail-ssl/issues",
+                "source": "https://github.com/ryoluo/sail-ssl"
+            },
+            "time": "2025-02-27T13:54:30+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,30 @@
+# Docker compose file used with Laravel Sail & devcontainers.json to set up a standardised dev environment.
+# Services:
+# - laravel.test: the monica instance
+# - nginx: allows serving the instance locally through HTTPS and using a self-signed certificate
+# - mysql: database
+# This file was created by Laravel Sail and updated by Sail-SSL (https://github.com/ryoluo/sail-ssl)
+
 services:
+    nginx:
+        image: 'nginx:latest'
+        ports:
+            - '${HTTP_PORT:-8000}:80'
+            - '${SSL_PORT:-443}:443'
+        environment:
+            - SSL_PORT=${SSL_PORT:-443}
+            - APP_SERVICE=${APP_SERVICE:-laravel.test}
+            - SERVER_NAME=${SERVER_NAME:-localhost}
+            - SSL_DOMAIN=${SSL_DOMAIN:-localhost}
+            - SSL_ALT_NAME=${SSL_ALT_NAME:-DNS:localhost}
+        volumes:
+            - 'sail-nginx:/etc/nginx/certs'
+            - './vendor/ryoluo/sail-ssl/nginx/templates:/etc/nginx/templates'
+            - './vendor/ryoluo/sail-ssl/nginx/generate-ssl-cert.sh:/docker-entrypoint.d/99-generate-ssl-cert.sh'
+        depends_on:
+            - ${APP_SERVICE:-laravel.test}
+        networks:
+            - sail
     laravel.test:
         build:
             context: ./vendor/laravel/sail/runtimes/8.4
@@ -52,5 +78,7 @@ networks:
     sail:
         driver: bridge
 volumes:
+    sail-nginx:
+        driver: local
     sail-mysql:
         driver: local

--- a/resources/js/components/settings/WebauthnConnector.vue
+++ b/resources/js/components/settings/WebauthnConnector.vue
@@ -326,8 +326,8 @@ export default {
         self.success = true;
         self.notify(self.$t('settings.webauthn_success'), true);
         self.currentkeys.push({
-          id: response.result.id,
-          name: response.result.name,
+          id: response.data.result.id,
+          name: response.data.result.name,
         });
       }).then(response => {
         if (redirect) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1339,9 +1339,9 @@
     "@types/node" "*"
 
 "@types/node@*":
-  version "24.2.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.2.1.tgz#83e41543f0a518e006594bb394e2cd961de56727"
-  integrity sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.3.0.tgz#89b09f45cb9a8ee69466f18ee5864e4c3eb84dec"
+  integrity sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==
   dependencies:
     undici-types "~7.10.0"
 
@@ -3134,9 +3134,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.199:
-  version "1.5.201"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.201.tgz#bdc8f13e828e2f65d2c925ab2e8b02604928632f"
-  integrity sha512-ZG65vsrLClodGqywuigc+7m0gr4ISoTQttfVh7nfpLv0M7SIwF4WbFNEOywcqTiujs12AUeeXbFyQieDICAIxg==
+  version "1.5.203"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.203.tgz#ef7fc2f7e1b816fa4535c861d1ec1348204142b6"
+  integrity sha512-uz4i0vLhfm6dLZWbz/iH88KNDV+ivj5+2SA+utpgjKaj9Q0iDLuwk6Idhe9BTxciHudyx6IvTvijhkPvFGUQ0g==
 
 elliptic@^6.5.3, elliptic@^6.5.5:
   version "6.6.1"


### PR DESCRIPTION
- use `response.data` since that's the structure declared by axios: https://axios-http.com/docs/res_schema
- use [sail-ssl](https://github.com/ryoluo/sail-ssl) to be able to access the instance locally through HTTPs
  - Needed in order to be able to test webauthn / passkeys since they require a non-localhost HTTPS connection

TODO
- [ ] update docs