### PR TITLE
feat(ci): add docker provenance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,6 +101,7 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           file: scripts/docker/Dockerfile
           context: .
+          provenance: true
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Hopefully this fixes the "incorrect base image" warning on Docker Hub
