### PR TITLE
fix: don't run fake user seeding automatically for local env

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -32,9 +32,9 @@ class DatabaseSeeder extends Seeder
 
         switch (App::environment()) {
             case 'testing':
-            case 'local':
                 $this->call(FakeUserTableSeeder::class);
                 break;
+            case 'local':
             case 'production':
                 break;
         }

--- a/database/seeds/FakeUserTableSeeder.php
+++ b/database/seeds/FakeUserTableSeeder.php
@@ -5,12 +5,7 @@ use Illuminate\Database\Seeder;
 
 class FakeUserTableSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     *
-     * @return void
-     */
-    public function run()
+    public function run(): void
     {
         Account::createDefault('John', 'Doe', 'admin@admin.com', 'admin0', null, 'en');
         Account::createDefault('Blank', 'State', 'blank@blank.com', 'blank0', null, 'en');


### PR DESCRIPTION
If needed, it can be run explicitly instead. This makes db:seed consistent between production and local